### PR TITLE
Fix a bug where 0 rounded to 2 decimal places was 0.0 and not 0.00

### DIFF
--- a/src/Formatting.elm
+++ b/src/Formatting.elm
@@ -315,11 +315,12 @@ roundTo n =
                         intPart =
                             truncate v
 
+                        fractionalPart : Int
                         fractionalPart =
                             (abs (round (v * exp))) - (abs (intPart * exp))
                     in
                         toString intPart
                             ++ "."
-                            ++ toString fractionalPart
+                            ++ print (padRight n '0' (s (toString fractionalPart)))
                 )
         )

--- a/test/FormattingTests.elm
+++ b/test/FormattingTests.elm
@@ -102,6 +102,8 @@ roundToTests =
             <| List.map check
                 [ ( "1235", roundTo 0, 1234.56 )
                 , ( "1234.0", roundTo 1, 1234 )
+                , ( "1234.00", roundTo 2, 1234.0 )
+                , ( "0.00", roundTo 2, 0 )
                 , ( "1234.57", roundTo 2, 1234.567 )
                 , ( "1234.567000", roundTo 6, 1234.567 )
                 , ( "-1235", roundTo 0, -1234.56 )


### PR DESCRIPTION
Tested with 2 new test cases:

```
( "1234.00", roundTo 2, 1234.0 )
( "0.00", roundTo 2, 0 )
```
