### PR TITLE
Remove testing dependencies from the main package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /.shake
 /dist
 /elm-stuff
+/test/elm-stuff
 /tests.js

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ all: tests.js
 
 tests.js: FORCE $(shell find src test -type f -name '*.elm' -o -name '*.js')
 	elm-make --yes --warn
-	elm-make test/Test.elm --yes --warn --output=$@
+	cd test && elm-make Test.elm --yes --warn --output=../$@ && cd ..
 	@ node $@
 
 FORCE:

--- a/test/elm-package.json
+++ b/test/elm-package.json
@@ -4,12 +4,14 @@
     "repository": "https://github.com/krisajenkins/formatting.git",
     "license": "MIT",
     "source-directories": [
-        "src"
+        ".",
+        "../src"
     ],
     "exposed-modules": [
-        "Formatting"
     ],
     "dependencies": {
+        "elm-community/elm-check": "1.0.0 <= v < 2.0.0",
+        "elm-community/elm-test": "1.1.0 <= v < 2.0.0",
         "elm-lang/core": "4.0.0 <= v < 5.0.0",
         "elm-lang/html": "1.0.0 <= v < 2.0.0"
     },


### PR DESCRIPTION
This pull request adds a separate elm-package.json to the /test folder. The effect is that the testing dependencies (notably elm-test, elm-check and random-extra) are no longer dependencies of the main package. 

When using this package in a package, it's nice not to have too many transitive dependencies. 

I've also adjusted the Makefile and .gitignore. The makefile could maybe by more elegant though. 
